### PR TITLE
fix: update GitHub username to correct broken link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -46,7 +46,7 @@ body:
         - label: "I checked and didn't find similar issue"
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/IAmTamal/Milan/blob/main/CONTRIBUTING.md)"
+        - label: "I have read the [Contributing Guidelines](https://github.com/tamalCodes/Milan/blob/main/CONTRIBUTING.md)"
           required: true
 
         - label: "I am willing to work on this issue (blank for no)"
@@ -56,4 +56,4 @@ body:
     attributes:
       value: |
         In case of emergencies contact me on [Twitter](https://twitter.com/mrTamall)
-        Feel free to check out other cool repositories [here](https://github.com/IAmTamal)
+        Feel free to check out other cool repositories [here](https://github.com/tamalCodes)

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -45,7 +45,7 @@ body:
         - label: "I checked and didn't find similar issue"
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/IAmTamal/Milan/blob/main/CONTRIBUTING.md)"
+        - label: "I have read the [Contributing Guidelines](https://github.com/tamalCodes/Milan/blob/main/CONTRIBUTING.md)"
           required: true
 
         - label: "I am willing to work on this issue (blank for no)"
@@ -55,5 +55,5 @@ body:
     attributes:
       value: |
         In case of emergencies contact me on [Twitter](https://twitter.com/mrTamall)
-        Feel free to check out other cool repositories [here](https://github.com/IAmTamal)
+        Feel free to check out other cool repositories [here](https://github.com/tamalCodes)
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -46,7 +46,7 @@ body:
         - label: "I checked and didn't find similar issue"
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/IAmTamal/Milan/blob/main/CONTRIBUTING.md)"
+        - label: "I have read the [Contributing Guidelines](https://github.com/tamalCodes/Milan/blob/main/CONTRIBUTING.md)"
           required: true
 
         - label: "I am willing to work on this issue (blank for no)"
@@ -56,4 +56,4 @@ body:
     attributes:
       value: |
         In case of emergencies contact me on [Twitter](https://twitter.com/mrTamall)
-        Feel free to check out other cool repositories [here](https://github.com/IAmTamal)
+        Feel free to check out other cool repositories [here](https://github.com/tamalCodes)

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -37,7 +37,7 @@ body:
         - label: "I checked and didn't find similar issue"
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/IAmTamal/Milan/blob/main/CONTRIBUTING.md)"
+        - label: "I have read the [Contributing Guidelines](https://github.com/tamalCodes/Milan/blob/main/CONTRIBUTING.md)"
           required: true
 
         - label: "I am willing to work on this issue (blank for no)"
@@ -47,4 +47,4 @@ body:
     attributes:
       value: |
         In case of emergencies contact me on [Twitter](https://twitter.com/mrTamall)
-        Feel free to check out other cool repositories [here](https://github.com/IAmTamal)
+        Feel free to check out other cool repositories [here](https://github.com/tamalCodes)


### PR DESCRIPTION
> add correct username of GitHub profile in all the issue forms

### Related Issue 

Closes: #791 

#### Changes made 👷🏻‍♂️

- While I would typically use `docs` as a commit message, fixing a broken link undoubtedly requires the use of `fix` in accordance with commit convention guidelines.

#### Screenshots <!--- (if any) --> 📸

![image](https://github.com/tamalCodes/Milan/assets/74038190/6f3c55e5-2916-4f23-970c-4d0d9038feb3)

![image](https://github.com/tamalCodes/Milan/assets/74038190/1c17d04d-fa3c-432c-be10-cb6aa8a150d3)
