### PR TITLE
feat: custom selection color text and background

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -37,3 +37,7 @@
     display: none;
   }
 }
+::selection {
+  background: #e26959;
+  color: white;
+}


### PR DESCRIPTION
closes #861 

### Changes Made
I added the functionality of selecting text with the color theme of the overall website
I have tested the functionality and it is working properly and is not depreciating any other feature