### PR TITLE
fix: grammar correction from 'continue as an user' to 'continue as a …

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -33,11 +33,10 @@
 }
 
 .crossButton {
-  padding: 0;
+  padding: 9;
   margin: 0;
   position: absolute;
-  right: 12px;
-  top: 7px;
+  right: 18px;
   font-size: 14px;
   border: 0;
   box-shadow: none;

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -168,7 +168,7 @@ const Navbar = () => {
                 id="user-signup-modal-btn"
                 onClick={() => navigateToURL("/user/register")}
               >
-                Continue as an User
+                Continue as a User
               </Button>
               <Button
                 className="btn modal-btn"
@@ -194,7 +194,7 @@ const Navbar = () => {
                 id="user-signup-modal-btn"
                 onClick={() => navigateToURL("/user/login")}
               >
-                Continue as an User
+                Continue as a User
               </Button>
               <Button
                 className="btn modal-btn"


### PR DESCRIPTION
fix: grammar in popup for login/sign up, position of cross button on popup

Related Issue
#1011

Changes made 👷🏻‍♂️
-Changed the popup text from "Continue as an user" to "Continue as a user"
-Changed the position of the cross button for better ux design purposes

<img width="533" alt="Screenshot 2023-08-08 at 3 57 18 PM" src="https://github.com/tamalCodes/Milan/assets/70923833/531fca9d-56ef-4f0b-b68a-dd06a2456ed7">


<img width="528" alt="Screenshot 2023-08-08 at 5 31 47 PM" src="https://github.com/tamalCodes/Milan/assets/70923833/e479e989-4a81-4b66-b439-07900ed94ce4">

